### PR TITLE
Support both spelling

### DIFF
--- a/uw_space/__init__.py
+++ b/uw_space/__init__.py
@@ -47,13 +47,17 @@ class Facilities(object):
 
     def __process_json(self, json_data):
         objs = []
-        facilitys = json_data.get("Facilitys")
-        for facility in facilitys:
-            status = facility.get("Status")
-            fnumber = facility.get("FacilityNumber")
-            if fnumber and len(fnumber):
-                fac = self.search_by_number(fnumber)
-                if fac:
-                    fac.status = status
-                    objs.append(fac)
+        if "Facilities" in json_data:
+            facilities = json_data.get("Facilities")
+        elif "Facilitys" in json_data:
+            facilities = json_data.get("Facilitys")
+        if facilities:
+            for facility in facilities:
+                status = facility.get("Status")
+                fnumber = facility.get("FacilityNumber")
+                if fnumber and len(fnumber):
+                    fac = self.search_by_number(fnumber)
+                    if fac:
+                        fac.status = status
+                        objs.append(fac)
         return objs

--- a/uw_space/resources/space/file/space/v2/facility.json_facility_code_MDR
+++ b/uw_space/resources/space/file/space/v2/facility.json_facility_code_MDR
@@ -1,0 +1,54 @@
+{
+    "TotalCount": 1,
+    "Facilities": [
+      {
+        "FacilityCode": "MDR",
+        "FacilityType": {
+          "Code": "BLDG",
+          "Description": "Building"
+        },
+        "Status": "A",
+        "AggregateFacilityNumber": "6471",
+        "Site": "SEA_MN",
+        "Name": "Madrona Hall",
+        "LongName": "Madrona Hall",
+        "LeasedOrOwned": "OWNED",
+        "StreetAddress": "4320 Little Canoe Channel NE",
+        "City": "Seattle",
+        "State": "WA",
+        "PostalCode": "98195",
+        "Country": "UNITED STATES",
+        "CountryCode2": "US",
+        "CountryCode3": "USA",
+        "County": "King",
+        "RepositoryTimeStamp": "2023-08-01T07:04:51.322-07:00",
+        "FacilityURI": {
+          "FacilityNumber": "6471",
+          "FacilityCode": "MDR",
+          "Description": "Madrona Hall",
+          "Href": "/space/v2/facility/6471.json"
+        },
+        "FacilityNumber": "6471"
+      }
+    ],
+    "Current": {
+      "Href": "/space/v2/facility.json?facility_type=&facility_code=MDR&status=&aggregate_number=&site=&name=&long_name=&leased_or_owned=&street=&city=&state=&postal_code=&changed_since_date=&page_start=1&page_size=10",
+      "FacilityType": null,
+      "FacilityCode": "MDR",
+      "Status": null,
+      "AggregateNumber": null,
+      "Site": null,
+      "Name": null,
+      "LongName": null,
+      "LeasedOrOwned": null,
+      "Street": null,
+      "City": null,
+      "State": null,
+      "PostalCode": null,
+      "PageStart": "1",
+      "PageSize": "10",
+      "ChangedSinceDate": null
+    },
+    "Next": null,
+    "Previous": null
+}

--- a/uw_space/resources/space/file/space/v2/facility/6471.json
+++ b/uw_space/resources/space/file/space/v2/facility/6471.json
@@ -1,0 +1,52 @@
+{
+  "Addresses": [
+    {
+      "Code": "1",
+      "PrimaryAddress": "Y",
+      "StreetAddress": "4320 Little Canoe Channel NE",
+      "City": "Seattle",
+      "State": "WA",
+      "PostalCode": "98195",
+      "Country": "UNITED STATES",
+      "CountryCode2": "US",
+      "CountryCode3": "USA",
+      "County": "King"
+    },
+    {
+      "Code": "2",
+      "PrimaryAddress": "N",
+      "StreetAddress": "4322 Little Canoe Channel NE",
+      "City": "Seattle",
+      "State": "WA",
+      "PostalCode": "98195",
+      "Country": "UNITED STATES",
+      "CountryCode2": "US",
+      "CountryCode3": "USA",
+      "County": "King"
+    }
+  ],
+  "AggregateFacilityNumber": "6471",
+  "FacilityType": {
+    "Code": "BLDG",
+    "Description": "Building"
+  },
+  "GrossSquareFeet": "141659",
+  "LeasedOrOwned": "OWNED",
+  "ModifiedDate": "9/22/2022 12:49:38 PM",
+  "Site": {
+    "Code": "SEA_MN",
+    "Description": "Seattle Main Campus"
+  },
+  "RepositoryTimeStamp": "2023-08-01T07:04:51.322-07:00",
+  "SpaceCount": 446,
+  "Status": "A",
+  "CenterPoint": {
+    "Latitude": 47.6601320001,
+    "Longitude": -122.305391,
+    "Href": "http://maps.google.com/maps?ll=47.6601320001,-122.305391"
+  },
+  "Name": "Madrona Hall",
+  "LongName": "Madrona Hall",
+  "FacilityCode": "MDR",
+  "FacilityNumber": "6471"
+}

--- a/uw_space/tests/test_facilities.py
+++ b/uw_space/tests/test_facilities.py
@@ -32,6 +32,21 @@ class TestSpace(TestCase):
             Facilities().search_by_code, "None"
         )
 
+        fac = Facilities().search_by_code("MDR")
+        self.assertEqual(len(fac), 1)
+        self.assertEqual(fac[0].json_data(),
+            {
+                'code': 'MDR',
+                'last_updated': '2022-09-22 12:49:38',
+                'latitude': 47.6601320001,
+                'longitude': -122.305391,
+                'name': 'Madrona Hall',
+                'number': '6471',
+                'site': 'Seattle Main Campus',
+                'status': 'A',
+                'type': 'Building'
+            })
+
     def test_search_by_number(self):
         fac = Facilities().search_by_number("1347")
         data['status'] = ''

--- a/uw_space/tests/test_facilities.py
+++ b/uw_space/tests/test_facilities.py
@@ -34,17 +34,16 @@ class TestSpace(TestCase):
 
         fac = Facilities().search_by_code("MDR")
         self.assertEqual(len(fac), 1)
-        self.assertEqual(fac[0].json_data(),
-            {
-                'code': 'MDR',
-                'last_updated': '2022-09-22 12:49:38',
-                'latitude': 47.6601320001,
-                'longitude': -122.305391,
-                'name': 'Madrona Hall',
-                'number': '6471',
-                'site': 'Seattle Main Campus',
-                'status': 'A',
-                'type': 'Building'
+        self.assertEqual(fac[0].json_data(), {
+            'code': 'MDR',
+            'last_updated': '2022-09-22 12:49:38',
+            'latitude': 47.6601320001,
+            'longitude': -122.305391,
+            'name': 'Madrona Hall',
+            'number': '6471',
+            'site': 'Seattle Main Campus',
+            'status': 'A',
+            'type': 'Building'
             })
 
     def test_search_by_number(self):


### PR DESCRIPTION
The production space payload has "Facilitys" whereas eval has "Facilities". Handle both.